### PR TITLE
Fix incompatibility with OTP23

### DIFF
--- a/.github/workflows/build-pynab.yml
+++ b/.github/workflows/build-pynab.yml
@@ -1,0 +1,28 @@
+name: Build on pynab
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [pynab-0.9.1]
+        include:
+        - target: pynab-0.9.1
+          cpu: arm1176
+          base_image: https://github.com/nabaztag2018/pynab/releases/download/v0.9.1/pynab-v0.9.1.img.xz
+    steps:
+    - uses: actions/checkout@v2
+    - uses: pguyot/arm-runner-action@v2
+      with:
+        base_image: ${{ matrix.base_image }}
+        cpu: ${{ matrix.cpu }}
+        image_additional_mb: 1024
+        commands: |
+            apt-get update -y --allow-releaseinfo-change
+            apt-get install --no-install-recommends -y erlang
+            rm -rf /home/pi/pynab/nabblockly
+            cp -Rp /nabblockly /home/pi/pynab/nabblockly
+            cd /home/pi/pynab/nabblockly
+            wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3 && chmod +x rebar3
+            ./rebar3 release

--- a/.github/workflows/build-raspios.yml
+++ b/.github/workflows/build-raspios.yml
@@ -1,0 +1,31 @@
+name: Build on various RaspberryPi OS versions
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [raspbian, raspios, raspios64]
+        include:
+        - target: raspbian
+          cpu: arm1176
+          base_image: raspbian_lite:latest
+        - target: raspios
+          cpu: arm1176
+          base_image: raspios_lite:latest
+        - target: raspios64
+          cpu: cortex-a53
+          base_image: raspios_lite_arm64:latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: pguyot/arm-runner-action@v2
+      with:
+        base_image: ${{ matrix.base_image }}
+        cpu: ${{ matrix.cpu }}
+        image_additional_mb: 1024
+        commands: |
+            apt-get update -y --allow-releaseinfo-change
+            apt-get install --no-install-recommends -y erlang
+            wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3 && chmod +x rebar3
+            ./rebar3 release

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ NabBlockly, est une interface de programmation par blocs des chorégraphies pour
 
     Depuis la version 0.6.3b de pynab, NabBlockly est installé par défaut des releases et fonctionne sur le port [8080](http://nabaztag.local:8080/). L'installation est d'ailleurs possible sur le port 80 en modifiant la configuration de Nginx.
 
-    NabBlockly requiert actuellement la branche master de pynab.
-
 2. Erlang
 
     Le code est développé avec la version 21 de Erlang/OTP.
@@ -19,13 +17,16 @@ NabBlockly, est une interface de programmation par blocs des chorégraphies pour
 
 ## Installation
 
-La compilation se fait avec [rebar3](http://github.com/erlang/rebar3).
+La compilation se fait avec [rebar3](http://github.com/erlang/rebar3). La
+version 3.15.1 est la dernière compatible avec OTP-21 qui est la version
+d'Erlang sur les images pynab actuelles à base de Buster.
+
 Attention à bien faire un clone dans pynab (nécessaire pour les sons).
 ```shell
 cd /home/pi/pynab
 git clone https://github.com/pguyot/nabblockly
 cd nabblockly
-wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3 && chmod +x rebar3
 ./rebar3 release
 ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
 {cowboy, "2.7.0"},
-{jiffy, "1.0.1"}
+{jiffy, "1.0.8"}
 ]}.
 
 {relx, [{release, { nabblockly, "0.1.0" },


### PR DESCRIPTION
Also fix README to refer to latest rebar version compatible with OTP21
Also add CI for RaspberryPi OS versions and pynab 0.9.1
Fixes #9 