### PR TITLE
Modification des dépendances d'installation

### DIFF
--- a/.github/workflows/build-pynab.yml
+++ b/.github/workflows/build-pynab.yml
@@ -20,7 +20,7 @@ jobs:
         image_additional_mb: 1024
         commands: |
             apt-get update -y --allow-releaseinfo-change
-            apt-get install --no-install-recommends -y erlang
+            apt-get install --no-install-recommends -y erlang-nox erlang-dev
             rm -rf /home/pi/pynab/nabblockly
             cp -Rp /nabblockly /home/pi/pynab/nabblockly
             cd /home/pi/pynab/nabblockly

--- a/.github/workflows/build-raspios.yml
+++ b/.github/workflows/build-raspios.yml
@@ -26,6 +26,6 @@ jobs:
         image_additional_mb: 1024
         commands: |
             apt-get update -y --allow-releaseinfo-change
-            apt-get install --no-install-recommends -y erlang
+            apt-get install --no-install-recommends -y erlang-nox erlang-dev
             wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3 && chmod +x rebar3
             ./rebar3 release

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ NabBlockly, est une interface de programmation par blocs des chorégraphies pour
 
     Le code est développé avec la version 21 de Erlang/OTP.
     ```shell
-    sudo apt-get install erlang
+    sudo apt-get install erlang-nox erlang-dev
     ```
 
 ## Installation


### PR DESCRIPTION
Modification des instructions d'installation pour les dépendances pour éviter d'installer toute la pile Xorg.

La version allégée de Debian pour la rasperry-pi viens sans installation de la pile graphique Xorg.

Cependant l'installation du paquet unique `erlang` installe de très nombreuses dépendances indirectes dont toute la pile graphique Xorg.


Cette pull-request permet de corriger le problème en installant seulement les paquets `erlang-nox erlang-dev` afin de garder un système de base léger.