### PR TITLE
Handle more versions of Erlang

### DIFF
--- a/.github/workflows/build-raspios.yml
+++ b/.github/workflows/build-raspios.yml
@@ -3,8 +3,9 @@ on:
   push:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
+      fail-fast: false
       matrix:
         target: [raspbian, raspios, raspios64]
         include:
@@ -27,5 +28,29 @@ jobs:
         commands: |
             apt-get update -y --allow-releaseinfo-change
             apt-get install --no-install-recommends -y erlang-nox erlang-dev
-            wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3 && chmod +x rebar3
+            erts_version=`erl +V 2>&1 | sed -E -e 's|.+ emulator version ||g'`
+            case "${erts_version}" in
+                "10.0"*|"10.1"*|"10.2"*|"10.3"*)
+                    # OTP 21
+                    wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3
+                    ;;
+                "10."*)
+                    # OTP 22
+                    wget https://github.com/erlang/rebar3/releases/download/3.18.0/rebar3
+                    ;;
+                "11."*)
+                    # OTP 23
+                    wget https://github.com/erlang/rebar3/releases/download/3.20.0/rebar3
+                    ;;
+                "12."*)
+                    # OTP 24
+                    # 3.23.0 is latest release and works with OTP24.
+                    # However, OTP27 has been released and future releases might not work
+                    wget https://github.com/erlang/rebar3/releases/download/3.23.0/rebar3
+                    ;;
+                *)
+                    wget https://s3.amazonaws.com/rebar3/rebar3
+                    ;;
+            esac
+            chmod +x rebar3
             ./rebar3 release

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ wget https://github.com/erlang/rebar3/releases/download/3.15.1/rebar3 && chmod +
 ./rebar3 release
 ```
 
+NabBlockly est aussi compatible avec des versions plus récentes d'Erlang/OTP et
+de rebar3. Par exemple, les paquets erlang des dernières images de raspios sont
+en version OTP-25.
+
+Pour ces systèmes, le fichier `rebar.config.script` ajuste les versions de
+cowboy et de jiffy. La démarche est la suivante :
+```shell
+git clone https://github.com/pguyot/nabblockly
+cd nabblockly
+wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
+./rebar3 upgrade --all
+./rebar3 release
+```
+
 ## Configuration
 
 NabBlockly comprend un serveur web qui remplace celui de Pynab :

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,9 @@
+case erlang:system_info(otp_release) of
+    "21" ++ _ -> CONFIG;
+    "22" ++ _ ->
+        lists:keyreplace(deps, 1, CONFIG, {deps, [{cowboy,"2.8.0"}, {jiffy,"1.1.1"}]});
+    "23" ++ _ ->
+        lists:keyreplace(deps, 1, CONFIG, {deps, [{cowboy,"2.8.0"}, {jiffy,"1.1.1"}]});
+    _ -> % OTP24 and higher
+        lists:keyreplace(deps, 1, CONFIG, {deps, [{cowboy,"2.9.0"}, {jiffy,"1.1.1"}]})
+end.


### PR DESCRIPTION
Bump ubuntu to 24.04 to benefit from newer qemu using latest arm runner action